### PR TITLE
docs: --pretrained-config help reflects warn-and-skip behavior

### DIFF
--- a/mist/cli/args.py
+++ b/mist/cli/args.py
@@ -264,7 +264,9 @@ def add_train_args(parser: ArgParser) -> None:
         type=str,
         default=None,
         help="Path to the source model's config.json for encoder compatibility "
-        "validation. Required when --pretrained-weights is set.",
+        "validation. Strongly recommended with --pretrained-weights; if "
+        "omitted, MIST warns and skips the compatibility check (weights still "
+        "load - incompatible tensors are skipped).",
     )
     g.add_argument(
         "--input-channel-strategy",


### PR DESCRIPTION
The help text claimed --pretrained-config is "Required when --pretrained-weights is set," but _validate_pretrained_config only warns and skips the compatibility check when it is omitted; load_pretrained_encoder still loads encoder weights (incompatible tensors skipped, strict=False). Reword to "strongly recommended" and describe the skip behavior.