### PR TITLE
feat(metrics): add lesion detection F1 (lesion_wise_f1)

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -1294,6 +1294,7 @@ and parameters — there is no requirement to evaluate every class the same way.
 | BraTS-style lesion-wise Dice | `lesion_wise_dice` | see [lesion-wise parameters](usage.md#lesion-wise-metric-parameters) |
 | BraTS-style lesion-wise HD95 | `lesion_wise_haus95` | see [lesion-wise parameters](usage.md#lesion-wise-metric-parameters) |
 | BraTS-style lesion-wise surface Dice | `lesion_wise_surf_dice` | see [lesion-wise parameters](usage.md#lesion-wise-metric-parameters) |
+| Lesion detection F1 | `lesion_wise_f1` | see [lesion-wise parameters](usage.md#lesion-wise-metric-parameters) |
 
 ### Example: different metrics per class
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -669,6 +669,7 @@ include and which metrics to compute, along with any metric-specific parameters:
 | `lesion_wise_dice`     | BraTS-style lesion-wise Dice                  | see below |
 | `lesion_wise_haus95`   | BraTS-style lesion-wise HD95 (mm)             | see below |
 | `lesion_wise_surf_dice`| BraTS-style lesion-wise surface Dice          | see below |
+| `lesion_wise_f1`       | Lesion **detection** F1 (harmonic mean of precision/recall) | see below |
 
 #### Lesion-wise metric parameters
 
@@ -677,6 +678,14 @@ and aggregate using `sum(scores) / (num_gt_above_thresh + num_fp)` — the same
 formula used by the BraTS (Brain Tumor Segmentation) challenge. This scoring
 penalizes both missed lesions and spurious predictions equally, regardless of
 lesion size.
+
+`lesion_wise_f1` instead scores lesion **detection**: a GT lesion above the
+volume threshold is a true positive (TP) when a predicted component overlaps its
+dilated footprint, undetected GT lesions are false negatives (FN), and unmatched
+predicted components are false positives (FP), giving `F1 = 2·TP / (2·TP + FP +
+FN)`. It uses the same `min_lesion_volume`, `dilation_iters`, and
+`gt_consolidation_iters` parameters below (but not `tolerance`), and is the
+detection metric used by the BraTS 2026 Brain Metastases challenge.
 
 | Parameter                 | Default | Description |
 |---------------------------|---------|-------------|

--- a/mist/metrics/lesion_wise_metrics.py
+++ b/mist/metrics/lesion_wise_metrics.py
@@ -76,7 +76,10 @@ def compute_lesion_wise_metrics(
         gt: Binary ground truth mask.
         spacing: Voxel spacing in mm (dx, dy, dz).
         metrics: Metrics to compute. Supported values: 'dice', 'haus95',
-            'surface_dice'.
+            'surface_dice', 'f1'. 'f1' is the lesion *detection* F1 score
+            (2*TP / (2*TP + FP + FN), where TP are detected GT lesions, FN are
+            undetected GT lesions, and FP are unmatched predicted components);
+            it is only produced under reduction='mean'.
         min_lesion_volume: Minimum GT lesion volume in mm³ to include.
             Lesions below this threshold are excluded from analysis.
         surface_dice_tolerance_mm: Tolerance in mm for surface Dice.
@@ -218,6 +221,16 @@ def compute_lesion_wise_metrics(
     if "surface_dice" in metrics:
         aggregate["lesion_wise_surf_dice"] = (
             sum(r["lesion_wise_surf_dice"] for r in results) / denominator
+        )
+
+    if "f1" in metrics:
+        # Lesion detection F1. TP = detected GT lesions, FN = undetected GT
+        # lesions, FP = predicted components matched to no GT lesion.
+        true_positives = sum(1 for r in results if r["detected"])
+        false_negatives = num_gt_above_thresh - true_positives
+        f1_denominator = 2 * true_positives + num_fp + false_negatives
+        aggregate["lesion_wise_f1"] = (
+            2 * true_positives / f1_denominator if f1_denominator > 0 else 0.0
         )
 
     return aggregate

--- a/mist/metrics/metrics_registry.py
+++ b/mist/metrics/metrics_registry.py
@@ -212,3 +212,37 @@ class LesionWiseSurfaceDice(Metric):
             ),
         )
         return result.get("lesion_wise_surf_dice", self.best)
+
+
+@register_metric
+class LesionWiseF1(Metric):
+    """Lesion detection F1 score (harmonic mean of precision and recall).
+
+    A GT lesion above the volume threshold is a true positive when a predicted
+    component overlaps its dilated footprint; undetected GT lesions are false
+    negatives and unmatched predicted components are false positives.
+    """
+
+    name = "lesion_wise_f1"
+    best = 1.0
+    worst = 0.0
+
+    def __call__(self, truth, prediction, spacing, **kwargs):
+        result = lesion_wise_metrics.compute_lesion_wise_metrics(
+            prediction,
+            truth,
+            spacing=spacing,
+            metrics=["f1"],
+            reduction="mean",
+            min_lesion_volume=kwargs.get(
+                "min_lesion_volume", LesionWiseMetricsConstants.MIN_LESION_VOLUME
+            ),
+            dilation_iters=kwargs.get(
+                "dilation_iters", LesionWiseMetricsConstants.DILATION_ITERS
+            ),
+            gt_consolidation_iters=kwargs.get(
+                "gt_consolidation_iters",
+                LesionWiseMetricsConstants.GT_CONSOLIDATION_ITERS,
+            ),
+        )
+        return result.get("lesion_wise_f1", self.best)

--- a/tests/metrics/test_lesion_wise_metrics.py
+++ b/tests/metrics/test_lesion_wise_metrics.py
@@ -471,3 +471,88 @@ def test_surface_distance_value_error_falls_back_to_worst_case():
     assert result["lesion_wise_haus95"] == pytest.approx(diagonal)
     # Surface Dice: 0.0 fallback / 1
     assert result["lesion_wise_surf_dice"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Lesion detection F1
+# ---------------------------------------------------------------------------
+
+LESION_C = (slice(8, 11), slice(8, 11), slice(8, 11))
+
+
+def test_f1_perfect_detection_is_one():
+    """All GT lesions detected with no FP → F1 == 1.0."""
+    gt = make_vol(LESION_A, LESION_B)
+    pred = make_vol(LESION_A, LESION_B)
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["f1"], min_lesion_volume=0.0, dilation_iters=1,
+    )
+    # TP=2, FP=0, FN=0 → 2*2 / (2*2 + 0 + 0) = 1.0
+    assert result["lesion_wise_f1"] == pytest.approx(1.0)
+
+
+def test_f1_false_negative():
+    """One undetected GT lesion lowers F1 (TP=1, FN=1, FP=0)."""
+    gt = make_vol(LESION_A, LESION_B)
+    pred = make_vol(LESION_A)
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["f1"], min_lesion_volume=0.0, dilation_iters=1,
+    )
+    # 2*1 / (2*1 + 0 + 1) = 2/3
+    assert result["lesion_wise_f1"] == pytest.approx(2.0 / 3.0)
+
+
+def test_f1_false_positive():
+    """One spurious predicted lesion lowers F1 (TP=1, FP=1, FN=0)."""
+    gt = make_vol(LESION_A)
+    pred = make_vol(LESION_A, LESION_B)
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["f1"], min_lesion_volume=0.0, dilation_iters=1,
+    )
+    # 2*1 / (2*1 + 1 + 0) = 2/3
+    assert result["lesion_wise_f1"] == pytest.approx(2.0 / 3.0)
+
+
+def test_f1_false_negative_and_false_positive():
+    """FN and FP together: TP=1, FN=1, FP=1 → F1 = 0.5."""
+    gt = make_vol(LESION_A, LESION_B)
+    pred = make_vol(LESION_A, LESION_C)  # detects A, misses B, FP at C
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["f1"], min_lesion_volume=0.0, dilation_iters=1,
+    )
+    # 2*1 / (2*1 + 1 + 1) = 0.5
+    assert result["lesion_wise_f1"] == pytest.approx(0.5)
+
+
+def test_f1_all_false_positive_is_zero():
+    """No detectable GT but a predicted lesion → all FP → F1 == 0.0."""
+    gt = make_vol(LESION_A)
+    pred = make_vol(LESION_B)
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["f1"],
+        min_lesion_volume=1000.0,  # filter all GT lesions
+        dilation_iters=1,
+    )
+    # num_gt_above_thresh=0 → TP=0, FN=0, FP=1 → 0 / (0 + 1 + 0) = 0.0
+    assert result["lesion_wise_f1"] == pytest.approx(0.0)
+
+
+def test_f1_empty_gt_and_pred_returns_empty():
+    """No GT and no prediction → {} (metric excluded, no penalty)."""
+    result = compute_lesion_wise_metrics(
+        make_vol(), make_vol(), SPACING, metrics=["f1"], min_lesion_volume=0.0,
+    )
+    assert result == {}
+    assert "lesion_wise_f1" not in result
+
+
+def test_f1_alongside_other_metrics():
+    """F1 is reported together with overlap metrics in one call."""
+    gt = make_vol(LESION_A, LESION_B)
+    pred = make_vol(LESION_A)
+    result = compute_lesion_wise_metrics(
+        pred, gt, SPACING, metrics=["dice", "f1"],
+        min_lesion_volume=0.0, dilation_iters=1,
+    )
+    assert result["lesion_wise_dice"] == pytest.approx(0.5)
+    assert result["lesion_wise_f1"] == pytest.approx(2.0 / 3.0)

--- a/tests/metrics/test_metrics_registry.py
+++ b/tests/metrics/test_metrics_registry.py
@@ -48,6 +48,7 @@ def test_registry_contains_all_metrics():
         "lesion_wise_dice",
         "lesion_wise_haus95",
         "lesion_wise_surf_dice",
+        "lesion_wise_f1",
     }
     assert expected_names.issubset(set(METRIC_REGISTRY.keys()))
 
@@ -163,6 +164,36 @@ def test_lesion_wise_surf_dice_perfect_overlap(lesion_masks):
     metric = get_metric("lesion_wise_surf_dice")
     result = metric(gt, pred, spacing, min_lesion_volume=0.0, dilation_iters=1)
     assert result == pytest.approx(1.0)
+
+
+def test_lesion_wise_f1_registered():
+    """lesion_wise_f1 should be in the metric registry."""
+    assert "lesion_wise_f1" in METRIC_REGISTRY
+
+
+def test_lesion_wise_f1_perfect_overlap(lesion_masks):
+    """lesion_wise_f1 returns 1.0 when every GT lesion is detected with no FP."""
+    gt, pred, spacing = lesion_masks
+    metric = get_metric("lesion_wise_f1")
+    result = metric(gt, pred, spacing, min_lesion_volume=0.0, dilation_iters=1)
+    assert result == pytest.approx(1.0)
+
+
+def test_lesion_wise_f1_all_gt_filtered_with_fp_returns_zero(lesion_masks):
+    """All GT filtered but pred non-empty → all FP → F1 = 0.0."""
+    gt, pred, spacing = lesion_masks
+    metric = get_metric("lesion_wise_f1")
+    result = metric(gt, pred, spacing, min_lesion_volume=10000.0, dilation_iters=1)
+    assert result == pytest.approx(0.0)
+
+
+def test_lesion_wise_f1_empty_returns_best(lesion_masks):
+    """Empty GT and pred → {} → registry returns best (no-penalty convention)."""
+    _, pred, spacing = lesion_masks
+    metric = get_metric("lesion_wise_f1")
+    empty = np.zeros_like(pred)
+    result = metric(empty, empty, spacing, min_lesion_volume=0.0, dilation_iters=1)
+    assert result == metric.best
 
 
 def test_lesion_wise_dice_min_volume_kwarg_forwarded(lesion_masks):


### PR DESCRIPTION
Adds a lesion-wise detection F1 metric: a GT lesion above the volume threshold is a true positive when a predicted component overlaps its dilated footprint, undetected GT lesions are false negatives, and unmatched predicted components are false positives — F1 = 2*TP / (2*TP + FP + FN). Reuses the existing lesion-matching/FP counting in compute_lesion_wise_metrics, registers a lesion_wise_f1 metric (higher-is-better, so mist_rank handles it automatically), and documents it in usage.md and advanced_topics.md.

This is the lesion-detection metric used by the BraTS 2026 Brain Metastases challenge, so it lets local CV ranking mirror the official scoring.